### PR TITLE
Add Flask web API server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,8 @@ RUN pip install --no-cache-dir --upgrade pip \
 # Copy application code
 COPY . .
 
+# Expose API port
+EXPOSE 5000
+
 # Default command
-CMD ["python", "main.py"]
+CMD ["python", "api.py"]

--- a/README.md
+++ b/README.md
@@ -92,14 +92,31 @@ read [these instructions](model/README.md)
 ## Docker
 
 You can run the demo without setting up a local Python environment by building
-the provided Docker image.  From the repository root run:
+the provided Docker image. From the repository root run:
 
 ```bash
 docker build -t handwriting-synthesis .
 docker run --rm -v $(pwd)/img:/app/img handwriting-synthesis
 ```
-
 The generated SVG samples will appear in the `img/` directory.
+
+### Web API
+
+The Docker image now exposes a simple web API. Start the container and map the
+port to your host:
+
+```bash
+docker run --rm -p 5000:5000 handwriting-synthesis
+```
+
+You can then request handwriting synthesis via HTTP:
+
+```bash
+curl "http://localhost:5000/handwrite?text=Hello%20World" > out.svg
+```
+
+Optional query parameters `style` and `bias` may be provided to control the
+appearance of the generated text.
 
 ## Contribute
 

--- a/api.py
+++ b/api.py
@@ -1,0 +1,56 @@
+from flask import Flask, request, send_file, jsonify
+from handwriting_synthesis import Hand
+import tempfile
+import os
+
+app = Flask(__name__)
+hand = Hand()
+
+
+@app.route('/handwrite', methods=['GET'])
+def handwrite():
+    text = request.args.get('text')
+    if not text:
+        return jsonify({'error': 'text parameter required'}), 400
+
+    lines = text.split('\n')
+
+    style = request.args.get('style')
+    bias = request.args.get('bias')
+
+    styles = None
+    biases = None
+
+    if style is not None:
+        try:
+            style_index = int(style)
+            styles = [style_index for _ in lines]
+        except ValueError:
+            return jsonify({'error': 'style must be an integer'}), 400
+
+    if bias is not None:
+        try:
+            bias_value = float(bias)
+            biases = [bias_value for _ in lines]
+        except ValueError:
+            return jsonify({'error': 'bias must be a float'}), 400
+
+    with tempfile.NamedTemporaryFile(suffix='.svg', delete=False) as tmp:
+        tmp_filename = tmp.name
+
+    try:
+        hand.write(
+            filename=tmp_filename,
+            lines=lines,
+            biases=biases,
+            styles=styles
+        )
+        return send_file(tmp_filename, mimetype='image/svg+xml')
+    finally:
+        if os.path.exists(tmp_filename):
+            os.remove(tmp_filename)
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 matplotlib>=2.1.0
-pandas>= 0.22.0
+pandas>=0.22.0
 scikit-learn>=0.19.1
 scipy>=1.0.0
 svgwrite>=1.1.12
 tensorflow==2.12.0
 tensorflow-probability==0.20.1
+flask==2.2.5


### PR DESCRIPTION
## Summary
- add new `api.py` server providing `/handwrite` endpoint
- expose port and launch `api.py` in Dockerfile
- document API usage in README
- ensure requirements list Flask

## Testing
- `python -m py_compile api.py`
- `pytest -q`