### PR TITLE
Add PNG output support to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,26 +109,30 @@ port to your host:
 docker run --rm -p 5000:5000 handwriting-synthesis
 ```
 
-You can then request handwriting synthesis via HTTP:
+You can then request handwriting synthesis via HTTP. By default the API
+returns SVG images, but PNG output can be requested with the `format`
+parameter:
 
 ```bash
-curl "http://localhost:5000/handwrite?text=Hello%20World" > out.svg
+curl "http://localhost:5000/handwrite?text=Hello%20World&format=png" > out.png
 ```
 
 Optional query parameters `style` and `bias` may be provided to control the
 appearance of the generated text.
 
 To generate multiple images in one request, use the batch endpoint. Send a
-JSON payload containing a `texts` list. Optional `styles` and `biases` lists can
-be provided to control the appearance of each item.
+JSON payload containing a `texts` list. Optional `styles`, `biases` and
+`format` fields can be provided to control the appearance of each item and
+the returned image type.
 
 ```bash
 curl -X POST -H "Content-Type: application/json" \
-     -d '{"texts": ["Hello", "World"]}' \
+     -d '{"texts": ["Hello", "World"], "format": "png"}' \
      http://localhost:5000/handwrite_batch > out.zip
 ```
 
-The response is a zip file containing one SVG for each input string.
+The response is a zip file containing one image for each input string in
+the requested format.
 
 ## Contribute
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ svgwrite>=1.1.12
 tensorflow==2.12.0
 tensorflow-probability==0.20.1
 flask==2.2.5
+cairosvg>=2.5.2


### PR DESCRIPTION
## Summary
- allow API output as PNG using CairoSVG
- document PNG option in README
- add CairoSVG to requirements

## Testing
- `python -m py_compile api.py`
- `pip install -q -r requirements.txt` *(fails: Could not connect to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_6854791f77d08321af2cc47d31f4d3ba