### PR TITLE
Fix extra padding in SVG output

### DIFF
--- a/handwriting_synthesis/hand/_draw.py
+++ b/handwriting_synthesis/hand/_draw.py
@@ -9,12 +9,10 @@ def _draw(strokes, lines, filename, stroke_colors=None, stroke_widths=None):
     stroke_widths = stroke_widths or [2] * len(lines)
 
     line_height = 60
-    view_width = 1000
-    view_height = line_height * (len(strokes) + 1)
 
-    dwg = svgwrite.Drawing(filename=filename)
-    dwg.viewbox(width=view_width, height=view_height)
-    dwg.add(dwg.rect(insert=(0, 0), size=(view_width, view_height), fill='white'))
+    # store processed coordinates so we can compute final bounds
+    processed = []
+    path_params = []
 
     initial_coord = np.array([0, -(3 * line_height / 4)])
     for offsets, line, color, width in zip(strokes, lines, stroke_colors, stroke_widths):
@@ -24,23 +22,43 @@ def _draw(strokes, lines, filename, stroke_colors=None, stroke_widths=None):
             continue
 
         offsets[:, :2] *= 1.5
-        strokes = drawing.offsets_to_coords(offsets)
-        strokes = drawing.denoise(strokes)
-        strokes[:, :2] = drawing.align(strokes[:, :2])
+        pts = drawing.offsets_to_coords(offsets)
+        pts = drawing.denoise(pts)
+        pts[:, :2] = drawing.align(pts[:, :2])
 
-        strokes[:, 1] *= -1
-        strokes[:, :2] -= strokes[:, :2].min() + initial_coord
-        strokes[:, 0] += (view_width - strokes[:, 0].max()) / 2
+        pts[:, 1] *= -1
+        pts[:, :2] -= pts[:, :2].min() + initial_coord
 
-        prev_eos = 1.0
-        p = "M{},{} ".format(0, 0)
-        for x, y, eos in zip(*strokes.T):
-            p += '{}{},{} '.format('M' if prev_eos == 1.0 else 'L', x, y)
-            prev_eos = eos
-        path = svgwrite.path.Path(p)
-        path = path.stroke(color=color, width=width, linecap='round').fill("none")
-        dwg.add(path)
+        processed.append(pts)
+        path_params.append((pts, color, width))
 
         initial_coord[1] -= line_height
+
+    if not processed:
+        svgwrite.Drawing(filename=filename).save()
+        return
+
+    all_pts = np.vstack([p[:, :2] for p in processed])
+    min_x, min_y = all_pts.min(axis=0)
+    max_x, max_y = all_pts.max(axis=0)
+
+    width = max_x - min_x
+    height = max_y - min_y
+
+    dwg = svgwrite.Drawing(filename=filename)
+    dwg.viewbox(width=width, height=height)
+    dwg.add(dwg.rect(insert=(0, 0), size=(width, height), fill='white'))
+
+    for pts, color, w in path_params:
+        pts[:, 0] -= min_x
+        pts[:, 1] -= min_y
+        prev_eos = 1.0
+        p = []
+        for x, y, eos in pts:
+            p.append('{}{},{}'.format('M' if prev_eos == 1.0 else 'L', x, y))
+            prev_eos = eos
+        path = svgwrite.path.Path(' '.join(p))
+        path = path.stroke(color=color, width=w, linecap='round').fill("none")
+        dwg.add(path)
 
     dwg.save()


### PR DESCRIPTION
## Summary
- remove fixed width/height from `_draw` and compute bounding box
- reposition strokes so generated images have no padding

## Testing
- `python -m py_compile handwriting_synthesis/hand/_draw.py`
- `pylint $(git ls-files '*.py')` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854833797c08321a115f8876d96505a